### PR TITLE
Bump Guzzle to allow 3.8.* as well as 3.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "guzzle/guzzle": "~3.7.0"
+        "guzzle/guzzle": ">=3.7.0,<3.9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7.0"


### PR DESCRIPTION
This is required so we can use latest Guzzle.
