### PR TITLE
Check for unset reasons

### DIFF
--- a/lib/Sift/Client.php
+++ b/lib/Sift/Client.php
@@ -5,9 +5,7 @@ namespace Sift;
 use Guzzle\Http\Client as HttpClient;
 use Guzzle\Http\Exception\HttpException as GuzzleHttpException;
 use Guzzle\Http\Message\Request;
-use Sift\Event;
 use Sift\Exception\HttpException as SiftHttpException;
-use Sift\Label;
 
 /**
  * A minimal wrapper around the Sift REST API.
@@ -51,7 +49,7 @@ class Client
 
     /**
      * Fetch the configured HTTP client
-     * @return Guzzle\Http\Client
+     * @return HttpClient
      */
     public function getHttpClient()
     {
@@ -62,9 +60,9 @@ class Client
      * Post an event to the REST API and return decoded JSON response.
      *
      * @see https://siftscience.com/docs/references/events-api
-     * @see Sift\Event
+     * @see Event
      *
-     * @param Sift\Event $event
+     * @param Event $event
      * @return array
      */
     public function postEvent(Event $event)
@@ -82,10 +80,10 @@ class Client
      * Label a given user and return decoded JSON response.
      *
      * @see https://siftscience.com/docs/references/labels-api
-     * @see Sift\Label
+     * @see Label
      *
      * @param string     $userId
-     * @param Sift\Label $label
+     * @param Label $label
      * @return array
      */
     public function labelUser(Label $label)
@@ -105,7 +103,7 @@ class Client
      * @see https://siftscience.com/docs/getting-scores
      *
      * @param string $userId
-     * @return Sift\Score
+     * @return Score
      */
     public function userScore($userId)
     {

--- a/lib/Sift/Event.php
+++ b/lib/Sift/Event.php
@@ -63,7 +63,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-create-order
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function createOrderEvent(array $fields)
     {
@@ -76,7 +76,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-transaction
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function transactionEvent(array $fields)
     {
@@ -89,7 +89,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-create-account
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function createAccountEvent(array $fields)
     {
@@ -102,7 +102,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-update-account
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function updateAccountEvent(array $fields)
     {
@@ -115,7 +115,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-add-item-to-cart
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function addItemToCartEvent(array $fields)
     {
@@ -128,7 +128,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#remove-item-from-cart
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function removeItemFromCartEvent(array $fields)
     {
@@ -141,7 +141,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-submit-review
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function submitReviewEvent(array $fields)
     {
@@ -154,7 +154,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-send-message
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function sendMessageEvent(array $fields)
     {
@@ -167,7 +167,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-login
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function loginEvent(array $fields)
     {
@@ -180,7 +180,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-logout
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function logoutEvent(array $fields)
     {
@@ -194,7 +194,7 @@ class Event extends Payload
      *
      * @see https://siftscience.com/docs/references/events-api#event-link-session-to-user
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function linkSessionToUserEvent(array $fields)
     {
@@ -208,7 +208,7 @@ class Event extends Payload
      * @see https://siftscience.com/docs/references/events-api#events-custom-events
      * @param string $type   event type
      * @param array  $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function customEvent($type, array $fields)
     {
@@ -220,7 +220,7 @@ class Event extends Payload
      *
      * @param string $type   event type
      * @param array  $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     protected static function factory($type, array $fields)
     {
@@ -232,7 +232,7 @@ class Event extends Payload
      * Create an event from an array of fields.
      *
      * @param array $fields event data
-     * @return Sift\Event
+     * @return Event
      */
     public static function construct(array $fields)
     {

--- a/lib/Sift/Payload.php
+++ b/lib/Sift/Payload.php
@@ -10,7 +10,7 @@ class Payload extends \ArrayObject
     /**
      * Returns a copy of this payload with an updated API key
      * @param string $apiKey
-     * @return Sift\Event
+     * @return Event
      */
     public function withKey($apiKey)
     {

--- a/lib/Sift/Score.php
+++ b/lib/Sift/Score.php
@@ -19,8 +19,8 @@ class Score
      * $data specifies a non-zero 'status' property.
      *
      * @param array $data
-     * @return Sift\Score
-     * @throws Sift\Exception\ScoreException
+     * @return Score
+     * @throws \Sift\Exception\ScoreException
      */
     public static function fromArray(array $data)
     {
@@ -31,7 +31,7 @@ class Score
         return new self(
             $data['user_id'],
             $data['score'],
-            isset($data['reasons']) ? $data['reasons'] : []
+            isset($data['reasons']) ? $data['reasons'] : array()
         );
     }
 

--- a/lib/Sift/Score.php
+++ b/lib/Sift/Score.php
@@ -31,7 +31,7 @@ class Score
         return new self(
             $data['user_id'],
             $data['score'],
-            $data['reasons']
+            isset($data['reasons']) ? $data['reasons'] : []
         );
     }
 


### PR DESCRIPTION
Unrated users can have no 'reasons'. This should be handled without throwing a fatal.